### PR TITLE
Remove background set for body

### DIFF
--- a/shared/custom-element-v2.css
+++ b/shared/custom-element-v2.css
@@ -147,7 +147,6 @@ td,th{
   box-sizing:border-box;
 }
 body{
-  background-image:linear-gradient(135deg, #f3f4f5, #d3dff3);
   font-family:Inter,sans-serif;
   font-size:14px;
   font-weight:400;


### PR DESCRIPTION
### Motivation

The background of the custom elements does not fit the UI. Probably generation process should ignore the home background property because it is meant to be used for `body` of a whole app.

Draft wf step:
![image](https://user-images.githubusercontent.com/9218736/119329716-cbc09400-bc85-11eb-983b-e6be3d3b1876.png)

Publish workflow step:
![image](https://user-images.githubusercontent.com/9218736/119329836-e430ae80-bc85-11eb-83b0-f90714d1ac5e.png)


### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [ ] All code (including 3rd party libraries is releaseable under the MIT license or is compatible with the MIT license (i.e. permissive)
- [ ] All third party libraries include appropriate licenses and are compatible with the MIT license (i.e. permissive)

### How to test

If manual testing is required, what are the steps?
